### PR TITLE
Improve documentation for using dev3000 with any Next.js project

### DIFF
--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -919,6 +919,7 @@ console.log('DEBUG:', { platform, chromePath, cdpPort })
 ## Support
 
 For issues and questions:
-- GitHub Issues: https://github.com/vercel-labs/dev3000/issues
+- GitHub Issues: https://github.com/automationjp/dev3000/issues
+- Upstream (original): https://github.com/vercel-labs/dev3000
 - Check [Troubleshooting](#troubleshooting) section above
 - Review Docker logs: `docker compose logs -f dev3000`

--- a/README.md
+++ b/README.md
@@ -424,11 +424,13 @@ This will:
 
 ## Releasing (Maintainers Only)
 
+**Note**: This fork does not publish to npm. For the official npm package, see the [upstream repository](https://github.com/vercel-labs/dev3000).
+
 We use a semi-automated release process that handles testing while accommodating npm's 2FA requirement:
 
 ### Option 1: GitHub Actions + Manual Publish (Recommended)
 
-1. Go to [Actions](https://github.com/vercel-labs/dev3000/actions) → "Prepare Release"
+1. Go to [Actions](https://github.com/automationjp/dev3000/actions) → "Prepare Release"
 2. Select release type (patch/minor/major) and run
 3. Wait for tests to pass on all platforms
 4. Download the release artifact (tarball)


### PR DESCRIPTION
## Summary

This PR improves documentation to clarify how to use dev3000 with **any** Next.js project, not just the included example.

## Changes

### Documentation Improvements
- **README.md**: Enhanced Windows/Docker setup section with clear path conversion examples
- **GETTING_STARTED.md**: Added comprehensive Docker setup guide with architecture diagrams
- **docker/README.md**: Clarified setup for user's own projects vs included example

### Key Additions
- Windows path to WSL2 path conversion table
- Visual architecture diagram showing Docker setup
- Explicit instructions: only ONE line needs changing in docker-compose.yml
- Emphasis that no configuration files are needed in user's project

### Attribution & Respect
- Restored and maintained original author credit "_Made by elsigh_"
- Added "About This Fork" section explaining relationship to upstream
- Credited automation co., ltd as maintainer
- Updated repository links to automationjp/dev3000 while preserving upstream references

### Technical Updates
- Fixed Dockerfile to ensure dev3000 is in PATH for node user
- Updated docker-compose.yml references to point to user projects
- Added examples for different Windows drive letters (C:\, D:\)

## Testing

✅ Docker build completed successfully
✅ Container starts and runs dev3000 v0.0.95
✅ Next.js app responding on port 3000
✅ MCP server responding on port 3684
✅ Logs UI accessible with proper redirects

## Addresses

This PR addresses user feedback that documentation didn't clearly explain how to use dev3000 with arbitrary projects, only the included example.

## Notes

- This fork does not publish to npm
- For official npm package, users should use upstream: https://github.com/vercel-labs/dev3000
- Maintains full respect and attribution to original project and author

🙏 Huge thanks to [@elsigh](https://github.com/elsigh) and the original dev3000 team for creating this amazing tool!