### PR TITLE
Exclude .pnpm-store from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docker/*.env
 example/nextjs15/node_modules/
 example/nextjs15/.next/
 example/nextjs15/out/
+example/nextjs15/.pnpm-store/
 
 # Temporary files from automation scripts
 .dev3000-chrome.pid


### PR DESCRIPTION
## Summary

Exclude the local pnpm cache directory from version control to prevent repository bloat.

## Changes

- Added `example/nextjs15/.pnpm-store/` to .gitignore
- Deleted existing .pnpm-store directory (15,081 files)

## Rationale

The .pnpm-store directory is a local pnpm cache that:
- Contains over 15,000 cached package files
- Should not be committed to version control
- Is automatically regenerated by pnpm when needed
- Would significantly increase repository size if committed

## Impact

- ✅ Reduces repository size
- ✅ Prevents accidental commits of cache files
- ✅ Follows best practices for pnpm projects
- ✅ No impact on functionality (cache regenerates automatically)