### PR TITLE
Chore: post-upstream sync PR

### DIFF
--- a/docs/ops/upstream-sync-20251030.md
+++ b/docs/ops/upstream-sync-20251030.md
@@ -1,0 +1,8 @@
+# Upstream sync record
+
+- Date: $(date)
+- Action: Merge upstream/main into main
+- Reason: Keep fork up-to-date; includes v0.0.107 release and log filename utility fixes.
+- Notes:
+  - Verified with `pnpm run lint` and `pnpm run typecheck`
+  - No functional changes beyond upstream merge


### PR DESCRIPTION
This PR adds a small ops note documenting the upstream/main merge that was performed.

Changes
- Add docs/ops/upstream-sync-YYYYMMDD.md with the merge record

Why
- Provide a concrete branch to attach a PR for review/CI after upstream sync
- No functional changes; codebase already synced and verified

Validation
- pnpm run lint → OK
- pnpm run typecheck → OK
