### PR TITLE
make: ログ駆動開発対応とテスト追加

### DIFF
--- a/scripts/make-helpers.sh
+++ b/scripts/make-helpers.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shared helpers for Makefile recipes to enable log-driven workflows.
+# Source this file at the beginning of recipes: `. scripts/make-helpers.sh`
+
+# section "Title"
+section() {
+  printf "\n===== %s =====\n" "$*"
+}
+
+# kv key value
+kv() {
+  printf -- "- %s: %s\n" "$1" "${2:-}"
+}
+
+# hint "message"
+hint() {
+  printf -- "👉 %s\n" "$*"
+}
+
+# run_cmd "Name" <command...>
+# Respects D3K_LOG_DRY_RUN=1 for safe testing. Emits intent, command, timing, exit code.
+run_cmd() {
+  local name="$1"; shift
+  local cmd=("$@")
+  local t0=$(date +%s)
+  section "RUN: $name"
+  kv Command "${cmd[*]}"
+  if [[ "${D3K_LOG_DRY_RUN:-}" == "1" ]]; then
+    kv Mode "DRY-RUN"
+    return 0
+  fi
+  set +e
+  "${cmd[@]}"
+  local rc=$?
+  set -e
+  local t1=$(date +%s)
+  kv Exit "$rc"
+  kv Time "$(($t1-$t0))s"
+  if [[ $rc -ne 0 ]]; then
+    hint "Command failed. Inspect logs above, adjust and re-run."
+  fi
+  return $rc
+}
+
+# ensure_container "name" "up-command..."
+# Starts container if not running. DRY-RUN aware.
+ensure_container() {
+  local cname="$1"; shift
+  if docker ps --format '{{.Names}}' | grep -q "^${cname}$"; then
+    kv "Container ${cname}" "running"
+    return 0
+  fi
+  kv "Container ${cname}" "not running"
+  if [[ "${D3K_LOG_DRY_RUN:-}" == "1" ]]; then
+    hint "DRY-RUN: would start container '${cname}'"
+    return 0
+  fi
+  section "Start container: ${cname}"
+  "$@"
+}
+

--- a/test/make-logs.spec.ts
+++ b/test/make-logs.spec.ts
@@ -1,0 +1,29 @@
+import { execSync, spawnSync } from 'node:child_process'
+import { describe, it, expect } from 'vitest'
+
+function sh(cmd: string, env: Record<string, string | undefined> = {}) {
+  const res = spawnSync('bash', ['-lc', cmd], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  })
+  return { code: res.status ?? 1, out: res.stdout ?? '', err: res.stderr ?? '' }
+}
+
+describe('Make log-driven diagnostics', () => {
+  it('cdp-check prints section header and respects DRY-RUN', () => {
+    const { code, out } = sh('make cdp-check', { D3K_LOG_DRY_RUN: '1' })
+    expect(code).toBe(0)
+    expect(out).toContain('=== CDP Reachability Check ===')
+    expect(out).toContain('RUN: node scripts/check-cdp.mjs')
+    expect(out).toContain('Mode: DRY-RUN')
+  })
+
+  it('dev-up delegates to cdp-check (log presence)', { timeout: 20000 }, () => {
+    const { code, out } = sh('make dev-up', { D3K_LOG_DRY_RUN: '1' })
+    expect(code).toBe(0)
+    expect(out).toContain('Step 1: Starting Docker containers...')
+    expect(out).toContain('Step 2: Waiting for Next.js to be ready...')
+    expect(out).toContain('Step 3: Launching Chrome with CDP...')
+    expect(out).toContain('Step 4: Running cdp-check diagnostics')
+  })
+})


### PR DESCRIPTION
概要:\n- Makefile をログ駆動開発に寄せて強化\n- scripts/make-helpers.sh 追加 (section/kv/run_cmd/ensure_container)\n- dev-up: run_cmd と DRY-RUN 対応、CDP 検証は cdp-check に委譲\n- cdp-check: コンテナ未起動時の自動起動、ログ出力整備\n- テスト: cdp-check / dev-up のログ存在を検証\n\n使い方:\n- DRY-RUN: D3K_LOG_DRY_RUN=1 を付与すれば安全に実行経路とログだけ確認可能\n\n検証:\n- pnpm run lint / typecheck OK